### PR TITLE
input definition link

### DIFF
--- a/data/docs.yaml
+++ b/data/docs.yaml
@@ -8,6 +8,7 @@ toc:
    subsections:
      - title: Starting Pilosa
      - title: Sample Project
+     - title: Input Definition
      - title: What's Next?
        slug: what-s-next
  - title: Tutorials


### PR DESCRIPTION
We separated the input definition doc out to its own page, but wanted to make is a sub section of getting started.