### PR TITLE
Generate version dynamically in shortcodes and partials for use in docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,7 +7,9 @@ googleAnalytics = "UA-96186501-1"
 ignoreFiles = []
 
 [params]
-    version = "v0.8"
+    version_major = "0"
+    version_minor = "8"
+    version_patch = "3"
     company = "Pilosa"
     logo = "logo.svg"
     logo_png = "logo.png"

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -42,9 +42,11 @@
 
     <div   class='single-body-content col-lg-8 pl-4 py-5' id="content">
       {{ $version := replaceRE "^/docs/([^/]+)/.*" "$1" .URL }}
-      {{ if not (or (eq $version "latest") (eq $version .Site.Params.version)) }}
+      {{ if not (or (eq $version "latest") (eq $version (partial "version_minor.html" .))) }}
           <div class="warning">
-              You are viewing the documentation for Pilosa {{ $version }}. View the <a href="/docs/latest/{{ .Title | urlize }}/">latest documentation for Pilosa {{ .Site.Params.version }}</a>.
+              You are viewing the documentation for Pilosa {{ $version }}. View the <a href="/docs/latest/{{ .Title | urlize }}/">latest documentation for Pilosa {{ partial "version.html" . }}</a>.
+
+
           </div>
       {{ end }}
       {{ .Content }}

--- a/layouts/partials/version.html
+++ b/layouts/partials/version.html
@@ -1,0 +1,1 @@
+v{{ .Site.Params.version_major }}.{{ .Site.Params.version_minor }}.{{ .Site.Params.version_patch }}

--- a/layouts/partials/version_minor.html
+++ b/layouts/partials/version_minor.html
@@ -1,0 +1,1 @@
+v{{ .Site.Params.version_major }}.{{ .Site.Params.version_minor }}

--- a/layouts/shortcodes/param.html
+++ b/layouts/shortcodes/param.html
@@ -1,0 +1,1 @@
+{{ $.Page.Site.Param (.Get 0) }}

--- a/layouts/shortcodes/version.html
+++ b/layouts/shortcodes/version.html
@@ -1,0 +1,1 @@
+v{{ $.Page.Site.Param "version_major" }}.{{ $.Page.Site.Param "version_minor" }}.{{ $.Page.Site.Param "version_patch" }}


### PR DESCRIPTION
This adds shortcode `{{< version >}}` and partials `{{ partial "version.html" . }}` and `{{ partial "version_minor.html" . }}`. The shortcode is especially useful for our docs.