### PR TITLE
minor fix for home page styling

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -291,7 +291,7 @@ footer a:hover{
 
 @media (min-width: 1199px) {
 
-  .concepts-img-container:{
+  .concepts-img-container{
     display: block;
   }
   .concepts-card-container{
@@ -372,7 +372,7 @@ footer a:hover{
   display: flex;
   flex-direction: column;
 
-  width:556px;
+  max-width: 556px;
   min-height: 520px;
   margin: 13px;
   border-radius: 3px;


### PR DESCRIPTION
This PR removes the hard width on the use cases block on the homepage to allow for better responsive styling:
![FireShot Capture 050 - Pilosa - Home - localhost](https://user-images.githubusercontent.com/1513140/58731916-a14ce080-83b5-11e9-9460-627d7d61a51e.png)
