### PR TITLE
Enable 'unsafe' html

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -76,3 +76,6 @@ ignoreFiles = []
 
 [taxonomies]
     featured = "featured"
+
+[markup.goldmark.renderer]
+    unsafe = true


### PR DESCRIPTION
This enables (re-enables?) HTML tags embedded in markdown, which are used somewhat often in the content. It may have been disabled here after a Hugo update.

This option is called "unsafe" due to the potential for javascript injection, but I don't imagine it's a problem here.

https://discourse.gohugo.io/t/raw-html-getting-omitted-in-0-60-0/22032