### PR TITLE
Add 'apt update --fix-missing' to address deploy failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       - run: wget https://github.com/gohugoio/hugo/releases/download/v0.29/hugo_0.29_Linux-64bit.tar.gz
       - run: tar -xvzf hugo_0.29_Linux-64bit.tar.gz
       - run: sudo cp hugo /go/bin/
+      - run: sudo apt update --fix-missing
       - run: sudo apt install -y python-pip
       - run: sudo pip install awscli
       - run: aws configure set preview.cloudfront true
@@ -22,6 +23,7 @@ jobs:
       - run: wget https://github.com/gohugoio/hugo/releases/download/v0.29/hugo_0.29_Linux-64bit.tar.gz
       - run: tar -xvzf hugo_0.29_Linux-64bit.tar.gz
       - run: sudo cp hugo /go/bin/
+      - run: sudo apt update --fix-missing
       - run: sudo apt install -y python-pip
       - run: sudo pip install awscli
       - run: aws configure set preview.cloudfront true


### PR DESCRIPTION
latest deploy failed with this error:

```
E: Failed to fetch http://deb.debian.org/debian/pool/main/d/dbus/libdbus-1-3_1.12.16-1_amd64.deb  404  Not Found [IP: 199.232.166.132 80]
E: Failed to fetch http://deb.debian.org/debian/pool/main/d/dbus/dbus_1.12.16-1_amd64.deb  404  Not Found [IP: 199.232.166.132 80]
E: Failed to fetch http://deb.debian.org/debian/pool/main/j/jquery/libjs-jquery_3.3.1~dfsg-3_all.deb  404  Not Found [IP: 199.232.166.132 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

Exited with code exit status 100
CircleCI received exit code 100
```